### PR TITLE
Run tests against running container on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
-# Stuff shared by all builds
-install:
-  - pip install ".[dev]"
-script:
-  - ./.ci/travis_checks.sh
-
+services:
+  - docker
 
 matrix:
   include:
@@ -12,19 +8,15 @@ matrix:
       os: linux
       python: 3.6
     
-    # This is actually a py3.6 + Mac OSX build (with conda).
-    # The mac + python version pairings for Travis are weird,
-    # and as of this writing 3.6 isn't supported. For more, see
-    # https://docs.travis-ci.com/user/multi-os/#python-example-unsupported-languages
-    - os: osx
-      language: generic
-      before_install:
-        - wget https://repo.continuum.io/miniconda/Miniconda3-4.3.21-MacOSX-x86_64.sh -O miniconda.sh
-        - bash miniconda.sh -b -p $HOME/miniconda
-        - export PATH="$HOME/miniconda/bin:$PATH"
-        - hash -r
-        - conda config --set always_yes yes --set changeps1 no
-        - conda update -q conda
-        - conda info -a
-        - conda create -q -n testenv python=3.6.12 nose pytest
-        - source activate testenv
+before_install:
+  - pip install -U pip
+  - pip install awscli
+  - aws s3 cp s3://autofocus/models/multilabel_model_20190407.pkl ./autofocus/predict/models/
+  - docker build -t test-autofocus-serve ./autofocus/predict/
+  - docker ps -a
+  - docker run -d -p 8000:8000 test-autofocus-serve
+install:
+  - pip install ".[dev]"
+script:
+  - ./.ci/travis_checks.sh
+  - ./.ci/local_checks.sh


### PR DESCRIPTION
Resolves #110 by modifying the travis config to:
 - copying the trained model from AWS,
 - building a local image on travis from the pushed branch,
 - running the two sets of tests.

**Note** This doesn't work with the OSX build because `Services are not supported on osx` for travis. However, docker is OS agnostic, so this shouldn't matter. (it's not clear to me what the OSX build is for)

To do before/on merging:
 - [ ] add AWS credentials to travis environment variables for repo (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`)




Pull Request Checklist
 - [x] Pull request has been made against `dev` branch.
 - [x] Pull request includes a description of the change and the reason behind it.
 - [x] Pull request [uses keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to close relevant [issues](https://github.com/uptake/autofocus/issues).
 - [ ] Pull request includes unit tests for any new functionality.
 - [ ] README and docs have been updated.
 - [x] `./.ci/local_checks.sh` passes locally. (The app must be running. See `README.md` for instructions.)

Maintainer's responsibilities:
- [ ] `_version.py` has been updated.
- [ ] `CHANGELOG.md` has been updated.
- [ ] Updated app container has been pushed with current version number.
- [ ] App container version number has been updated everywhere in README.
